### PR TITLE
Adding typeo functionality

### DIFF
--- a/libs/hermes/hermes.typeo/pyproject.toml
+++ b/libs/hermes/hermes.typeo/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hermes.typeo"
-version = "0.1.3"
+version = "0.1.4"
 description = "Utilities for running functions as scripts"
 authors = ["Alec Gunny <alec.gunny@gmail.com>"]
 readme = "README.md"

--- a/libs/hermes/hermes.typeo/tests/test_typeo.py
+++ b/libs/hermes/hermes.typeo/tests/test_typeo.py
@@ -108,7 +108,7 @@ def test_maybe_sequence_funcs(annotation):
     set_argv("--a", *"test")
     assert maybe_func() == "test yes sequence"
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
 
         @typeo
         def bad_maybe_func(a: Union[str, annotation[int]]):


### PR DESCRIPTION
Simplifying and better documentation some typeo functions, as well as adding:

- Ability to return optional arguments to subcommands from the main function as a dictionary
- Creation of a `[typeo.base]` table in the typeo config that can be used for common arguments to subsections and commands

Incrementing version to 0.1.4 to reflect feature additions.