### PR TITLE
Incorporate `**kwargs` into onnx exporting

### DIFF
--- a/libs/hermes/hermes.quiver/hermes/quiver/exporters/exporter.py
+++ b/libs/hermes/hermes.quiver/hermes/quiver/exporters/exporter.py
@@ -211,6 +211,10 @@ class Exporter(metaclass=abc.ABCMeta):
                 config for outputs, the inferred shapes will be
                 compared by name using the output names. Otherwise,
                 they'll be added to the config dynamically
+            **kwargs:
+                Any other keyword arguments to pass to `Exporter.export`.
+                Consult the relevant documentation.
+             
         Returns:
             The path to which the model was exported
         """

--- a/libs/hermes/hermes.quiver/hermes/quiver/exporters/exporter.py
+++ b/libs/hermes/hermes.quiver/hermes/quiver/exporters/exporter.py
@@ -181,6 +181,7 @@ class Exporter(metaclass=abc.ABCMeta):
         version: int,
         input_shapes: _SHAPES_TYPE = None,
         output_names: Optional[Sequence[str]] = None,
+        **kwargs
     ):
         """Export a particular version of this platform's model
 
@@ -240,7 +241,7 @@ class Exporter(metaclass=abc.ABCMeta):
         export_path = self.fs.join(
             self.config.name, str(version), conventions[self.platform]
         )
-        self.export(model_fn, export_path)
+        self.export(model_fn, export_path, **kwargs)
         return export_path
 
     @property
@@ -262,5 +263,5 @@ class Exporter(metaclass=abc.ABCMeta):
             )
 
     @abc.abstractmethod
-    def export(self, model_fn, export_path, verbose=0):
+    def export(self, model_fn, export_path, verbose=0, **kwargs):
         pass

--- a/libs/hermes/hermes.quiver/hermes/quiver/exporters/exporter.py
+++ b/libs/hermes/hermes.quiver/hermes/quiver/exporters/exporter.py
@@ -181,7 +181,7 @@ class Exporter(metaclass=abc.ABCMeta):
         version: int,
         input_shapes: _SHAPES_TYPE = None,
         output_names: Optional[Sequence[str]] = None,
-        **kwargs
+        **kwargs,
     ):
         """Export a particular version of this platform's model
 
@@ -214,7 +214,7 @@ class Exporter(metaclass=abc.ABCMeta):
             **kwargs:
                 Any other keyword arguments to pass to `Exporter.export`.
                 Consult the relevant documentation.
-             
+
         Returns:
             The path to which the model was exported
         """

--- a/libs/hermes/hermes.quiver/hermes/quiver/exporters/torch_onnx.py
+++ b/libs/hermes/hermes.quiver/hermes/quiver/exporters/torch_onnx.py
@@ -117,7 +117,7 @@ class TorchOnnx(Exporter, metaclass=TorchOnnxMeta):
             shapes = {name: shape for name, shape in zip(output_names, shapes)}
         return shapes
 
-    def export(self, model_fn, export_path, verbose=0):
+    def export(self, model_fn, export_path, verbose=0, **kwargs):
         inputs, dynamic_axes = [], {}
         for input in self.config.input:
             if input.dims[0] == -1:
@@ -143,6 +143,7 @@ class TorchOnnx(Exporter, metaclass=TorchOnnxMeta):
             input_names=[x.name for x in self.config.input],
             output_names=[x.name for x in self.config.output],
             dynamic_axes=dynamic_axes or None,
+            **kwargs
         )
 
         # write the written bytes and return

--- a/libs/hermes/hermes.quiver/hermes/quiver/model.py
+++ b/libs/hermes/hermes.quiver/hermes/quiver/model.py
@@ -185,7 +185,7 @@ class Model:
 
         try:
             export_path = exporter(
-                model_fn, version, input_shapes, output_names
+                model_fn, version, input_shapes, output_names, **kwargs
             )
             self.config.write()
         except Exception:

--- a/libs/hermes/hermes.quiver/tests/unit/exporters/test_torch_onnx_exporter.py
+++ b/libs/hermes/hermes.quiver/tests/unit/exporters/test_torch_onnx_exporter.py
@@ -1,5 +1,7 @@
+from unittest.mock import ANY, patch
+
 import pytest
-from unittest.mock import patch, ANY
+
 from hermes.quiver import Model, Platform
 from hermes.quiver.exporters import TorchOnnx
 
@@ -44,18 +46,25 @@ def test_torch_onnx_exporter(temp_local_repo, torch_model):
     assert len(model2.config.input) == 1
     assert model2.config.input[0].name == "input_0"
 
+
 def test_torch_onnx_exporter_with_kwargs(temp_local_repo, torch_model):
     model_fn = torch_model
 
     model = Model("test", temp_local_repo, Platform.ONNX)
     exporter = TorchOnnx(model.config, model.fs)
-    
-    version_path = temp_local_repo.fs.join("test", "1")
-    temp_local_repo.fs.soft_makedirs(version_path) 
-    output_path = temp_local_repo.fs.join(version_path, "model.onnx")
-    
-    with patch("hermes.quiver.exporters.torch_onnx.torch.onnx.export") as mock:
-        exporter.export(model_fn, output_path, opset_version = 11)
-        mock.assert_called_with(model_fn,ANY,ANY,input_names=ANY,output_names=ANY,dynamic_axes=ANY, opset_version = 11)
 
-    
+    version_path = temp_local_repo.fs.join("test", "1")
+    temp_local_repo.fs.soft_makedirs(version_path)
+    output_path = temp_local_repo.fs.join(version_path, "model.onnx")
+
+    with patch("hermes.quiver.exporters.torch_onnx.torch.onnx.export") as mock:
+        exporter.export(model_fn, output_path, opset_version=11)
+        mock.assert_called_with(
+            model_fn,
+            ANY,
+            ANY,
+            input_names=ANY,
+            output_names=ANY,
+            dynamic_axes=ANY,
+            opset_version=11,
+        )

--- a/libs/hermes/hermes.quiver/tests/unit/exporters/test_torch_onnx_exporter.py
+++ b/libs/hermes/hermes.quiver/tests/unit/exporters/test_torch_onnx_exporter.py
@@ -47,6 +47,7 @@ def test_torch_onnx_exporter(temp_local_repo, torch_model):
     assert model2.config.input[0].name == "input_0"
 
 
+@pytest.mark.torch
 def test_torch_onnx_exporter_with_kwargs(temp_local_repo, torch_model):
     model_fn = torch_model
 

--- a/libs/hermes/hermes.quiver/tests/unit/exporters/test_torch_onnx_exporter.py
+++ b/libs/hermes/hermes.quiver/tests/unit/exporters/test_torch_onnx_exporter.py
@@ -1,5 +1,5 @@
 import pytest
-
+from unittest.mock import patch, ANY
 from hermes.quiver import Model, Platform
 from hermes.quiver.exporters import TorchOnnx
 
@@ -43,3 +43,19 @@ def test_torch_onnx_exporter(temp_local_repo, torch_model):
     exporter._check_exposed_tensors("input", input_shapes)
     assert len(model2.config.input) == 1
     assert model2.config.input[0].name == "input_0"
+
+def test_torch_onnx_exporter_with_kwargs(temp_local_repo, torch_model):
+    model_fn = torch_model
+
+    model = Model("test", temp_local_repo, Platform.ONNX)
+    exporter = TorchOnnx(model.config, model.fs)
+    
+    version_path = temp_local_repo.fs.join("test", "1")
+    temp_local_repo.fs.soft_makedirs(version_path) 
+    output_path = temp_local_repo.fs.join(version_path, "model.onnx")
+    
+    with patch("hermes.quiver.exporters.torch_onnx.torch.onnx.export") as mock:
+        exporter.export(model_fn, output_path, opset_version = 11)
+        mock.assert_called_with(model_fn,ANY,ANY,input_names=ANY,output_names=ANY,dynamic_axes=ANY, opset_version = 11)
+
+    


### PR DESCRIPTION
properly pass kwargs from export_version to Exporter.export function